### PR TITLE
Feature/update 4.0.0

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-OAUTH2_PROXY_VERSION="v3.2.0"
-OAUTH2_PROXY_CHECKSUM="fac3c8e8a809d4086d1dfd52c4897b79a49132fb97374bd0837f484ba002689a"
+OAUTH2_PROXY_VERSION="v4.0.0"
+OAUTH2_PROXY_CHECKSUM="20537fdeb0806ad9bc0273cb1e208a8802c3730c95eb53d31dce370e939c4e45"
 
 BP_DIR="$(cd $(dirname "$0"); pwd)"
 BUILD_DIR="$1"
@@ -11,13 +11,11 @@ BUILD_DIR="$1"
 mkdir -p "$BUILD_DIR/bin"
 
 echo "downloading oauth2_proxy..."
-wget --no-verbose "https://github.com/pusher/oauth2_proxy/releases/download/${OAUTH2_PROXY_VERSION}/oauth2_proxy-${OAUTH2_PROXY_VERSION}.linux-amd64.go1.11.tar.gz"
+wget --no-verbose "https://github.com/pusher/oauth2_proxy/releases/download/${OAUTH2_PROXY_VERSION}/oauth2_proxy-${OAUTH2_PROXY_VERSION}.linux-amd64.go1.12.1.tar.gz"
 mv oauth2_proxy-*.tar.gz oauth2_proxy.tar.gz
 echo "$OAUTH2_PROXY_CHECKSUM  oauth2_proxy.tar.gz" | sha256sum -c -
-tar -xzf oauth2_proxy.tar.gz
+tar -xzf oauth2_proxy.tar.gz -C "$BUILD_DIR/bin" --strip-components=1
 rm oauth2_proxy.tar.gz
-mv release/oauth2_proxy-linux-amd64 $BUILD_DIR/bin/oauth2_proxy
-rmdir release
 
 # write out a start script
 cp "${BP_DIR}"/../scripts/start_*.sh "${BUILD_DIR}/bin"

--- a/scripts/start_oauth2_proxy.sh
+++ b/scripts/start_oauth2_proxy.sh
@@ -10,24 +10,29 @@ if [ -z ${OAUTH2_PROXY_CLIENT_ID+x} ]; then echo "please set OAUTH2_PROXY_CLIENT
 if [ -z ${OAUTH2_PROXY_CLIENT_SECRET+x} ]; then echo "please set OAUTH2_PROXY_CLIENT_SECRET"; exit 1; fi
 if [ -z ${OAUTH2_PROXY_COOKIE_SECRET+x} ]; then echo "please set OAUTH2_PROXY_COOKIE_SECRET"; exit 1; fi
 
-OPTIONS=( )
+OAUTH2_PROXY_SET_XAUTHREQUEST="${OAUTH2_PROXY_SET_XAUTHREQUEST:-true}"
+export OAUTH2_PROXY_SET_XAUTHREQUEST
+
+OAUTH2_PROXY_PASS_ACCESS_TOKEN="${OAUTH2_PROXY_PASS_ACCESS_TOKEN:-true}"
+export OAUTH2_PROXY_PASS_ACCESS_TOKEN
+
+OAUTH2_PROXY_UPSTREAMS="${OAUTH2_PROXY_UPSTREAMS:-http://127.0.0.1:8080}"
+export OAUTH2_PROXY_UPSTREAMS
+
+OAUTH2_PROXY_HTTP_ADDRESS="${OAUTH2_PROXY_HTTP_ADDRESS:-http://:$PORT}"
+export OAUTH2_PROXY_HTTP_ADDRESS
+
 if [ -n "${OAUTH2_EMAIL_DOMAIN}" ]; then
-    for EMAIL_DOMAIN in $(echo "${OAUTH2_EMAIL_DOMAIN}" | tr ',' '\n'); do
-        OPTIONS=( "${OPTIONS[@]}" "--email-domain=${EMAIL_DOMAIN}" )
-    done
+    OAUTH2_PROXY_EMAIL_DOMAINS="${OAUTH2_EMAIL_DOMAIN}"
 else
-    OPTIONS=( "${OPTIONS[@]}" "--email-domain=*" )
+    OAUTH2_PROXY_EMAIL_DOMAINS="*"
 fi
+export OAUTH2_PROXY_EMAIL_DOMAINS
 
 if [ -n "${OAUTH2_GITHUB_ORG}" ]; then
-    OPTIONS=( "${OPTIONS[@]}" "--github-org=${OAUTH2_GITHUB_ORG}" )
+    OAUTH2_PROXY_GITHUB_ORG="${OAUTH2_GITHUB_ORG}"
+    export OAUTH2_PROXY_GITHUB_ORG
 fi
 
 echo "starting oauth2_proxy..."
-exec ./oauth2_proxy \
-       --http-address=http://:$PORT \
-       --provider="${OAUTH2_PROXY_PROVIDER}" \
-       --set-xauthrequest=true \
-       --pass-access-token=true \
-       --upstream=http://127.0.0.1:8080 \
-       "${OPTIONS[@]}"
+exec ./oauth2_proxy


### PR DESCRIPTION
Use the latest upstream version.

Additionally, use environment variables to configure oauth2 proxy, so settings can be overriden if needed.